### PR TITLE
adds continue_on_fail, adds retrier, adds logf

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Each definition is limited to the following properties:
 |branch|string|false|version control system branch to build in repository|
 |tag|string|false|version control system tag to build (cannot be used with branch or commit)|
 |commit|string|false|version control system commit to build (full commit hash)|
+|continue_on_fail|bool|false|continues with build process if a repository is flagged as continue_on_fail=true and fails to build|
 
 ### Example JSON
 
@@ -21,7 +22,8 @@ Each definition is limited to the following properties:
 	"name":"grace-circleci-builder",
 	"repository":"https://github.com/GSA/grace-circleci-builder",
 	"branch":"master",
-	"commit":"d8cbe5e2df067ba5a7eba66376911b064b48a4bf"
+	"commit":"d8cbe5e2df067ba5a7eba66376911b064b48a4bf",
+	"continue_on_fail": true
 },
 {
 	"name":"grace-tftest",
@@ -35,6 +37,8 @@ The above would execute a project build for the following two projects:
 `grace-circleci-builder (master at d8cbe5)`
 
 `grace-tftest (v0.1)`
+
+If the build for `grace-circleci-builder` failed, the builder would continue to `grace-tftest`.
 
 
 ### Command-line Flags Supported

--- a/circleci/circleci.go
+++ b/circleci/circleci.go
@@ -282,7 +282,7 @@ func (c *Client) findBuildSummary(project *Project, input *BuildProjectInput, af
 			continue
 		}
 		if input.matchSummary(summary) &&
-			//summary.User.Username == me.Username &&
+			summary.User.Username == me.Username &&
 			summary.QueuedAt.Sub(after) > 0 {
 			return summary, nil
 		}

--- a/circleci/circleci_test.go
+++ b/circleci/circleci_test.go
@@ -27,7 +27,7 @@ func TestFollow(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Logf("Project: %v\n", p)
-	err = c.FollowProject(p)
+	err = c.FollowProject(p, os.Stdout)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/main.go
+++ b/main.go
@@ -84,13 +84,13 @@ func runBuilds(token string, jobTimeout int, skipDays int, noSkip bool, entries 
 			return err
 		}
 		log.Printf("Following project with url: %s\n", entry.URL)
-		err = client.FollowProject(p)
+		err = client.FollowProject(p, os.Stdout)
 		if err != nil {
 			return fmt.Errorf("failed to follow project with URL: %s -> %v", entry.URL, err)
 		}
 
 		log.Printf("Searching for project with url: %s\n", entry.URL)
-		project, err := client.FindProject(func(p *circleci.Project) bool {
+		project, err := client.FindProject(os.Stdout, func(p *circleci.Project) bool {
 			return p.VcsURL == entry.URL
 		})
 		if err != nil {
@@ -126,7 +126,7 @@ func runBuilds(token string, jobTimeout int, skipDays int, noSkip bool, entries 
 func shouldSkip(client *circleci.Client, project *circleci.Project, input *circleci.BuildProjectInput, skipDays int) (bool, error) {
 	// this may need to be optimized to accept an 'after' date
 	// so we can stop iterating over old/stale job data
-	rawBuilds, err := client.FindBuildSummaries(project, input)
+	rawBuilds, err := client.FindBuildSummaries(project, os.Stdout, input)
 	if err != nil {
 		return false, err
 	}

--- a/main.go
+++ b/main.go
@@ -70,6 +70,7 @@ func main() {
 	}
 }
 
+//nolint: gocyclo
 func runBuilds(token string, jobTimeout int, skipDays int, noSkip bool, entries []*entry) error {
 	// loop over circleci project entries, resolving each project
 	// and executing a full build, if anything fails, return


### PR DESCRIPTION
Adds `continue_on_fail` parameter for repositories in the Buildfile
Adds `logf` function inside `circleci/circleci.go` to prevent repeated calls to Fprintf and an error check
Adds `retrier` function inside `circleci/circleci.go` to accommodate for API call failures