### PR TITLE
Use golangci lint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,4 +15,4 @@ workflows:
 
   test:
     jobs:
-      - test_go
+      - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,21 +1,14 @@
 version: 2
 jobs:
-  test_go:
+  test:
     docker:
       - image: circleci/golang:latest
     working_directory: /go/src/github.com/GSA/grace-circleci-builder
     steps:
       - checkout
       - run:
-          name: Install prerequisites
-          command: |
-            go get -u github.com/golang/dep/cmd/dep
-            go get -u github.com/alecthomas/gometalinter
-            gometalinter --install
-      - run:
           name: Run tests
-          command: |
-            make test_go
+          command: make test
 
 workflows:
   version: 2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,132 @@
+# This file contains all available configuration options
+# with their default values.
+
+# options for analysis running
+run:
+  # default concurrency is a available CPU number
+  concurrency: 4
+
+  # timeout for analysis, e.g. 30s, 5m, default is 1m
+  deadline: 5m
+
+  # exit code when at least one issue was found, default is 1
+  issues-exit-code: 1
+
+  # include test files or not, default is true
+  tests: true
+
+
+# output configuration options
+output:
+  # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"
+  format: colored-line-number
+
+  # print lines of code with issue, default is true
+  print-issued-lines: true
+
+  # print linter name in the end of issue text, default is true
+  print-linter-name: true
+
+
+# all available settings of specific linters
+linters-settings:
+  errcheck:
+    # report about not checking of errors in type assetions: `a := b.(MyStruct)`;
+    # default is false: such cases aren't reported by default.
+    check-type-assertions: false
+
+    # report about assignment of errors to blank identifier: `num, _ := strconv.Atoi(numStr)`;
+    # default is false: such cases aren't reported by default.
+    check-blank: false
+
+    # [deprecated] comma-separated list of pairs of the form pkg:regex
+    # the regex is used to ignore names within pkg. (default "fmt:.*").
+    # see https://github.com/kisielk/errcheck#the-deprecated-method for details
+    ignore: fmt:.*,io/ioutil:^Read.*
+
+  govet:
+    # report about shadowed variables
+    check-shadowing: true
+
+    # settings per analyzer
+    settings:
+      printf: # analyzer name, run `go tool vet help` to see all analyzers
+        funcs: # run `go tool vet help printf` to see available settings for `printf` analyzer
+          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Infof
+          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Warnf
+          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
+          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
+  golint:
+    # minimal confidence for issues, default is 0.8
+    min-confidence: 0.0
+  gofmt:
+    # simplify code: gofmt with `-s` option, true by default
+    simplify: true
+  gocyclo:
+    # minimal code complexity to report, 30 by default (but we recommend 10-20)
+    min-complexity: 10
+  maligned:
+    # print struct with more effective memory layout or not, false by default
+    suggest-new: true
+  goconst:
+    # minimal length of string constant, 3 by default
+    min-len: 3
+    # minimal occurrences count to trigger, 3 by default
+    min-occurrences: 3
+  depguard:
+    list-type: blacklist
+    include-go-root: false
+  misspell:
+    # Correct spellings using locale preferences for US or UK.
+    # Default is to use a neutral variety of English.
+    # Setting locale to US will correct the British spelling of 'colour' to 'color'.
+    locale: US
+    ignore-words:
+      - someword
+  lll:
+    # max line length, lines longer will be reported. Default is 120.
+    # '\t' is counted as 1 character by default, and can be changed with the tab-width option
+    line-length: 175
+    # tab width in spaces. Default to 1.
+    tab-width: 1
+  unused:
+    # treat code as a program (not a library) and report unused exported identifiers; default is false.
+    # XXX: if you enable this setting, unused will report a lot of false-positives in text editors:
+    # if it's called for subdir of a project it can't find funcs usages. All text editor integrations
+    # with golangci-lint call it on a directory with the changed file.
+    check-exported: false
+  unparam:
+    # Inspect exported functions, default is false. Set to true if no external program/library imports your code.
+    # XXX: if you enable this setting, unparam will report a lot of false-positives in text editors:
+    # if it's called for subdir of a project it can't find external interfaces. All text editor integrations
+    # with golangci-lint call it on a directory with the changed file.
+    check-exported: false
+  nakedret:
+    # make an issue if func has more lines of code than this setting and it has naked returns; default is 30
+    max-func-lines: 30
+  prealloc:
+    # XXX: we don't recommend using this linter before doing performance profiling.
+    # For most programs usage of prealloc will be a premature optimization.
+
+    # Report preallocation suggestions only on simpl e loops that have no returns/breaks/continues/gotos in them.
+    # True by default.
+    simple: true
+    range-loops: true # Report preallocation suggestions on range loops, true by default
+    for-loops: false # Report preallocation suggestions on for loops, false by default
+
+linters:
+  enable-all: true
+  disable:
+  fast: false
+
+  # Independently from option `exclude` we use default exclude patterns,
+  # it can be disabled by this option. To list all
+  # excluded by default patterns execute `golangci-lint run --help`.
+  # Default value for this option is true.
+  exclude-use-default: false
+
+  # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
+  max-issues-per-linter: 0
+
+  # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
+  max-same-issues: 0

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,31 @@
+GOBIN := $(GOPATH)/bin
+GODEP := $(GOBIN)/dep
+GOLANGCILINT := $(GOBIN)/golangci-lint
+GOSEC := $(GOBIN)/gosec
+
+.PHONY: default test lint dependencies
 default: test
 
-test: test_go
-
-test_go: validate_go
+test: lint
 	go test ./...
 
-validate_go: dep_ensure
-	gometalinter --deadline=240s --vendor ./...
-	gosec ./...
+lint: dependencies
+	$(GODEP) ensure
+	$(GOLANGCILINT) run ./...
+	$(GOSEC) ./...
 
-dep_init:
-ifeq (,$(wildcard ./Gopkg.toml))
-	dep init
+Gopkg.toml: $(GODEP)
+ifeq (,$(wildcard Gopkg.toml))
+	$(GODEP) init
 endif
 
-dep_ensure: dep_init
-	dep ensure
+dependencies: $(GOLANGCILINT) $(GOSEC) Gopkg.toml
+
+$(GOLANGCILINT):
+	go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
+
+$(GODEP):
+	go get -u github.com/golang/dep/cmd/dep
+
+$(GOSEC):
+	go get -u github.com/securego/gosec/cmd/gosec

--- a/circleci/circleci.go
+++ b/circleci/circleci.go
@@ -31,6 +31,7 @@ func (r RequestError) Error() string {
 	return r.Message
 }
 
+//nolint:unparam
 func retrier(intervalSecs int, attempts int, fn func() error) (err error) {
 	for attempt := 0; attempt < attempts; attempt++ {
 		err = fn()
@@ -193,6 +194,7 @@ func (c *Client) BuildProject(project *Project, logger io.Writer, input *BuildPr
 	if output.Status != 200 {
 		return nil, fmt.Errorf("failed to start project build: %s", output)
 	}
+	//nolint:godox
 	// 12/14/2018 - BLA
 	// TODO: Fix this if CircleCI ever fixes their API
 	// CircleCI currently doesn't return the buildNum or anything valuable when
@@ -233,7 +235,7 @@ func (e *summaryNotFoundError) Error() string {
 }
 
 // timeoutExceededError ... used internally to signify
-// a timeout ocurred while calling waiter
+// a timeout occurred while calling waiter
 type timeoutExceededError struct {
 	Message string
 }
@@ -294,7 +296,14 @@ func (c *Client) findBuildSummary(project *Project, logger io.Writer, input *Bui
 // to complete, if a build job fails, will return an error immediately
 // waitTimeout is the time to wait for the next build, before giving up
 // jobTimeout is the duration to wait for the build to complete, before giving up
-func (c *Client) WaitForProjectBuild(project *Project, logger io.Writer, input *BuildProjectInput, summary *BuildSummaryOutput, jobTimeout time.Duration, waitTimeout time.Duration, continueOnFail bool) error {
+func (c *Client) WaitForProjectBuild(
+	project *Project,
+	logger io.Writer,
+	input *BuildProjectInput,
+	summary *BuildSummaryOutput,
+	jobTimeout time.Duration,
+	waitTimeout time.Duration,
+	continueOnFail bool) error {
 	buildNum := summary.BuildNum
 	for {
 		build, err := c.waitForBuild(project, logger, buildNum, jobTimeout)
@@ -549,7 +558,7 @@ func FilterBuildSummariesByWorkflowStatus(input []*BuildSummaryOutput, status st
 			}
 		}
 	}
-	return
+	return output
 }
 
 // Project ... a genericized form of the response from calling
@@ -571,7 +580,7 @@ func ProjectFromURL(rawurl string) (*Project, error) {
 	}
 	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
 	if len(parts) < 2 {
-		return nil, fmt.Errorf("path not propertly formatted: %s", u)
+		return nil, fmt.Errorf("path not properly formatted: %s", u)
 	}
 	vcs := strings.Split(u.Host, ".")
 	if len(vcs) < 2 {

--- a/circleci/circleci_test.go
+++ b/circleci/circleci_test.go
@@ -41,6 +41,7 @@ type testCase struct {
 
 type testCaseCreator func() testCase
 
+//nolint:funlen
 func TestBuildProject(t *testing.T) {
 	c := &Client{}
 	t.Parallel()
@@ -48,7 +49,7 @@ func TestBuildProject(t *testing.T) {
 		func() testCase {
 			var tc testCase
 			tc.title = "BuildProject should fail if BuildProjectOutput.Status is not 200"
-			tc.requester = testBuildProjectRequest(t, 404, "", "", time.Now(), "", "", "")
+			tc.requester = testBuildProjectRequest(t, 404, "", "", "", "", "")
 			tc.tester = func(t *testing.T) {
 				c.requester = tc.requester
 				_, err := c.BuildProject(&Project{
@@ -69,7 +70,7 @@ func TestBuildProject(t *testing.T) {
 		func() testCase {
 			var tc testCase
 			tc.title = "BuildProject should fail if BuildProjectOutput.User.Username does not match Me.User.Username"
-			tc.requester = testBuildProjectRequest(t, 200, "self", "notSelf", time.Now(), "", "", "")
+			tc.requester = testBuildProjectRequest(t, 200, "self", "notSelf", "", "", "")
 			tc.tester = func(t *testing.T) {
 				c.requester = tc.requester
 				_, err := c.BuildProject(&Project{
@@ -90,7 +91,7 @@ func TestBuildProject(t *testing.T) {
 		func() testCase {
 			var tc testCase
 			tc.title = "BuildProject should fail if BuildProjectOutput.Revision does not match ProjectInput.Revision"
-			tc.requester = testBuildProjectRequest(t, 200, "self", "self", time.Now(), "", "1", "2")
+			tc.requester = testBuildProjectRequest(t, 200, "self", "self", "", "1", "2")
 			tc.tester = func(t *testing.T) {
 				c.requester = tc.requester
 				_, err := c.BuildProject(&Project{
@@ -111,7 +112,7 @@ func TestBuildProject(t *testing.T) {
 		func() testCase {
 			var tc testCase
 			tc.title = "BuildProject should fail if BuildProjectOutput.Branch does not match ProjectInput.Branch"
-			tc.requester = testBuildProjectRequest(t, 200, "self", "self", time.Now(), "", "1", "2")
+			tc.requester = testBuildProjectRequest(t, 200, "self", "self", "", "1", "2")
 			tc.tester = func(t *testing.T) {
 				c.requester = tc.requester
 				_, err := c.BuildProject(&Project{
@@ -130,7 +131,7 @@ func TestBuildProject(t *testing.T) {
 			return tc
 		},
 	}
-	var tt []testCase
+	tt := make([]testCase, len(tf))
 	for _, tc := range tf {
 		tt = append(tt, tc())
 	}
@@ -139,7 +140,8 @@ func TestBuildProject(t *testing.T) {
 	}
 }
 
-func testBuildProjectRequest(t *testing.T, bpoStatus int, meUser string, bsoUser string, bsoAfter time.Time, bsoTag string, bsoRevision string, bsoBranch string) requestFunc {
+//nolint:unparam
+func testBuildProjectRequest(t *testing.T, bpoStatus int, meUser string, bsoUser string, bsoTag string, bsoRevision string, bsoBranch string) requestFunc {
 	return func(c *Client, method string, path string, params url.Values, input interface{}, output interface{}) error {
 		now := time.Now()
 		switch val := output.(type) {

--- a/circleci/circleci_test.go
+++ b/circleci/circleci_test.go
@@ -132,8 +132,8 @@ func TestBuildProject(t *testing.T) {
 		},
 	}
 	tt := make([]testCase, len(tf))
-	for _, tc := range tf {
-		tt = append(tt, tc())
+	for i, tc := range tf {
+		tt[i] = tc()
 	}
 	for _, tc := range tt {
 		t.Run(tc.title, tc.tester)

--- a/main.go
+++ b/main.go
@@ -91,8 +91,8 @@ func runBuilds(token string, jobTimeout int, skipDays int, noSkip bool, entries 
 		}
 
 		log.Printf("Searching for project with url: %s\n", entry.URL)
+		entry := entry // pin!
 		project, err := client.FindProject(os.Stdout, func(p *circleci.Project) bool {
-			//nolint:scopelint
 			return p.VcsURL == entry.URL
 		})
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -91,8 +91,8 @@ func runBuilds(token string, jobTimeout int, skipDays int, noSkip bool, entries 
 		}
 
 		log.Printf("Searching for project with url: %s\n", entry.URL)
-		entry := entry // pin!
 		project, err := client.FindProject(os.Stdout, func(p *circleci.Project) bool {
+			//nolint:scopelint
 			return p.VcsURL == entry.URL
 		})
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -91,6 +91,7 @@ func runBuilds(token string, jobTimeout int, skipDays int, noSkip bool, entries 
 		}
 
 		log.Printf("Searching for project with url: %s\n", entry.URL)
+		entry := entry // pin!
 		project, err := client.FindProject(os.Stdout, func(p *circleci.Project) bool {
 			return p.VcsURL == entry.URL
 		})


### PR DESCRIPTION
- Uses golangci-lint instead of gometalinter
- Install dependencies in Makefile instead of CircleCI config
- Fixes the following linter findings (Closes #8 )

```
circleci/circleci_test.go:142:90: `testBuildProjectRequest` - `bsoAfter` is unused (unparam)
func testBuildProjectRequest(t *testing.T, bpoStatus int, meUser string, bsoUser string, bsoAfter time.Time, bsoTag string, bsoRevision string, bsoB
ranch string) requestFunc {
                                                                                         ^
circleci/circleci.go:236:14: `ocurred` is a misspelling of `occurred` (misspell)
// a timeout ocurred while calling waiter
             ^
circleci/circleci.go:574:36: `propertly` is a misspelling of `property` (misspell)
                return nil, fmt.Errorf("path not propertly formatted: %s", u)
                                                 ^
main.go:95:23: Using the variable on range scope `entry` in function literal (scopelint)
                        return p.VcsURL == entry.URL
                                           ^
circleci/circleci_test.go:133:2: Consider preallocating `tt` (prealloc)
        var tt []testCase
        ^
circleci/circleci.go:297: line is 209 characters (lll)
func (c *Client) WaitForProjectBuild(project *Project, logger io.Writer, input *BuildProjectInput, summary *BuildSummaryOutput, jobTimeout time.Dura
tion, waitTimeout time.Duration, continueOnFail bool) error {

circleci/circleci.go:552:2: naked return in func `FilterBuildSummariesByWorkflowStatus` with 38 lines of code (nakedret)
        return
        ^
```
- Ignores the following linter findings:

```
circleci/circleci.go:34:14: `retrier` - `intervalSecs` always receives `30` (unparam)

func retrier(intervalSecs int, attempts int, fn func() error) (err error) {
             ^

func (c *Client) WaitForProjectBuild(project *Project, logger io.Writer, input *BuildProjectInput, summary *BuildSummaryOutput, jobTimeout time.Dura
tion, waitTimeout time.Duration, continueOnFail bool) error {
circleci/circleci_test.go:44: Function 'TestBuildProject' is too long (95 > 60) (funlen)
func TestBuildProject(t *testing.T) {
circleci/circleci.go:197: circleci/circleci.go:197: Line contains TODO/BUG/FIXME: "TODO: Fix this if CircleCI ever fixes th..." (godox)
        // TODO: Fix this if CircleCI ever fixes their API
```
